### PR TITLE
Implement optional values

### DIFF
--- a/code-gen/src/poly_scribe_code_gen/matlab_gen.py
+++ b/code-gen/src/poly_scribe_code_gen/matlab_gen.py
@@ -154,9 +154,6 @@ def _transform_types(parsed_idl):
         for member in struct["members"]:
             foo = _matlab_transformer(member["type"])
 
-            if not member["default"] and len(foo[0]) >= 1:
-                member["default"] = '""' if foo[0][0] == "string" and not member["type"]["map"] else None
-
             if len(foo[1]) == 0:
                 variable_shape = "(1,1)"
             elif len(foo[1]) == 1:

--- a/code-gen/src/poly_scribe_code_gen/templates/matlab.jinja
+++ b/code-gen/src/poly_scribe_code_gen/templates/matlab.jinja
@@ -132,6 +132,10 @@ classdef {{ name }}{% if inheritance %} < {{ inheritance }}{% else %} < handle{%
                 obj.{{ member.name }} = json_data.{{ member.name }};
             {% endif %}
             {% endif %}
+            {% if member.default == None %}
+            else
+                error('Missing field: {{ member.name }}');
+            {% endif %}
             end
             {% endfor %}
         end

--- a/code-gen/src/poly_scribe_code_gen/templates/matlab.jinja
+++ b/code-gen/src/poly_scribe_code_gen/templates/matlab.jinja
@@ -40,7 +40,11 @@ classdef {{ name }}{% if inheritance %} < {{ inheritance }}{% else %} < handle{%
                     obj.{{ member.name }}{k}.store_to_struct();
             end
             {% else %}
-            json_data.{{ member.name }} = obj.{{ member.name }}.store_to_struct();
+            if iscell(obj.{{ member.name }})
+                json_data.{{ member.name }} = obj.{{ member.name }}{:}.store_to_struct();
+            else
+                json_data.{{ member.name }} = obj.{{ member.name }}.store_to_struct();
+            end
             {% endif %}
             {% endif %}
             {% else %}

--- a/code-gen/src/poly_scribe_code_gen/templates/serialize_func.jinja
+++ b/code-gen/src/poly_scribe_code_gen/templates/serialize_func.jinja
@@ -7,7 +7,7 @@ void serialize (Archive& t_archive)
 {% if def.members|length > 0 %}
     t_archive(
 {% for member in def.members %}
-        poly_scribe::make_scribe_wrap( "{{ member.name }}", {{ member.name }})
+        poly_scribe::make_scribe_wrap( "{{ member.name }}", {{ member.name }}{% if member.default %}, true{% endif %})
 {%- if not loop.last %},{% endif +%}
 {% endfor %}
     );

--- a/include/poly-scribe/factory.hpp
+++ b/include/poly-scribe/factory.hpp
@@ -24,9 +24,9 @@ namespace poly_scribe
 	/// Specialized for generic types.
 	///
 	template<class T>
-	inline ScribeWrapper<T> make_scribe_wrap( const std::string &t_name, T &&t_value, detail::GenericTag /*unused*/ )
+	inline ScribeWrapper<T> make_scribe_wrap( const std::string &t_name, T &&t_value, bool t_optional, detail::GenericTag /*unused*/ )
 	{
-		return { std::forward<T>( t_value ), t_name };
+		return { std::forward<T>( t_value ), t_name, t_optional };
 	}
 
 	///
@@ -35,9 +35,9 @@ namespace poly_scribe
 	///
 	template<class T>
 	inline typename std::enable_if_t<std::is_polymorphic_v<typename std::remove_reference_t<T>::element_type>, ScribeWrapper<ScribePointerWrapper<T>>> make_scribe_wrap(
-	    const std::string &t_name, T &&t_value, detail::SmartPointerTag /*unused*/ )
+	    const std::string &t_name, T &&t_value, bool t_optional, detail::SmartPointerTag /*unused*/ )
 	{
-		return { { std::forward<T>( t_value ) }, t_name };
+		return { { std::forward<T>( t_value ) }, t_name, t_optional };
 	}
 
 	///
@@ -47,9 +47,9 @@ namespace poly_scribe
 	///
 	template<class T>
 	inline typename std::enable_if_t<!std::is_polymorphic_v<typename std::remove_reference_t<T>::element_type>, ScribeWrapper<ScribePointerWrapper<T>>> make_scribe_wrap(
-	    const std::string &t_name, T &&t_value, detail::SmartPointerTag /*unused*/ )
+	    const std::string &t_name, T &&t_value, bool t_optional, detail::SmartPointerTag /*unused*/ )
 	{
-		return { { std::forward<T>( t_value ) }, t_name };
+		return { { std::forward<T>( t_value ) }, t_name, t_optional };
 	}
 
 	///
@@ -57,9 +57,9 @@ namespace poly_scribe
 	/// Specialized for container types.
 	///
 	template<class T>
-	inline ScribeWrapper<ScribeContainerWrapper<T>> make_scribe_wrap( const std::string &t_name, T &&t_value, detail::DynamicContainerTag /*unused*/ )
+	inline ScribeWrapper<ScribeContainerWrapper<T>> make_scribe_wrap( const std::string &t_name, T &&t_value, bool t_optional, detail::DynamicContainerTag /*unused*/ )
 	{
-		return { { std::forward<T>( t_value ) }, t_name };
+		return { { std::forward<T>( t_value ) }, t_name, t_optional };
 	}
 
 	///
@@ -88,12 +88,15 @@ namespace poly_scribe
 	/// \tparam T type to be wrapped
 	/// \param t_name name for the wrapped value. Similar to cereal::NameValuePair.
 	/// \param t_value value to be wrapped.
+	/// \param t_optional if true, the value is optional.
 	/// \return the wrap object.
+	/// \warning The wrapped object is only in a valid state if loaded or all contained values are optional and have a valid value.
+	/// \todo using validation methods it could also be checked if the values are in a valid state.
 	///
 	template<class T>
-	inline auto make_scribe_wrap( const std::string &t_name, T &&t_value )
+	inline auto make_scribe_wrap( const std::string &t_name, T &&t_value, bool t_optional = false )
 	{
-		return make_scribe_wrap( t_name, std::forward<T>( t_value ), typename detail::GetWrapperTag<typename std::remove_reference_t<T>>::type( ) );
+		return make_scribe_wrap( t_name, std::forward<T>( t_value ), t_optional, typename detail::GetWrapperTag<typename std::remove_reference_t<T>>::type( ) );
 	}
 } // namespace poly_scribe
 #endif

--- a/include/poly-scribe/factory.hpp
+++ b/include/poly-scribe/factory.hpp
@@ -68,9 +68,9 @@ namespace poly_scribe
 	/// Specialized for map container types.
 	///
 	template<class T>
-	inline ScribeWrapper<ScribeMapWrapper<T>> make_scribe_wrap( const std::string &t_name, T &&t_value, detail::MapContainerTag /*unused*/ )
+	inline ScribeWrapper<ScribeMapWrapper<T>> make_scribe_wrap( const std::string &t_name, T &&t_value, bool t_optional, detail::MapContainerTag /*unused*/ )
 	{
-		return { { std::forward<T>( t_value ) }, t_name };
+		return { { std::forward<T>( t_value ) }, t_name, t_optional };
 	}
 
 	///

--- a/include/poly-scribe/scribe-wrapper.hpp
+++ b/include/poly-scribe/scribe-wrapper.hpp
@@ -70,11 +70,23 @@ namespace poly_scribe
 		/// \remark Not specialized for any specific archive.
 		/// \tparam Archive archive type to load to.
 		/// \param t_archive archive to load from.
+		/// \todo check how the \p m_optional behaves with binary archives.
 		///
 		template<class Archive>
 		void CEREAL_LOAD_FUNCTION_NAME( Archive &t_archive )
 		{
-			t_archive( cereal::make_nvp( m_name, m_value ) );
+			try
+			{
+				t_archive( cereal::make_nvp( m_name, m_value ) );
+			}
+			catch( const cereal::Exception &t_exception )
+			{
+				if( m_optional && std::string( t_exception.what( ) ).find( "provided NVP" ) != std::string::npos )
+				{
+					return;
+				}
+				throw t_exception;
+			}
 		}
 	};
 

--- a/include/poly-scribe/scribe-wrapper.hpp
+++ b/include/poly-scribe/scribe-wrapper.hpp
@@ -39,6 +39,7 @@ namespace poly_scribe
 		// NOLINTNEXTLINE(cppcoreguidelines-avoid-const-or-ref-data-members)
 		Type m_value;       ///< Wrapped value.
 		std::string m_name; ///< Name used to serialize the value.
+		bool m_optional;    ///< True, if the wrapped value is optional.
 
 		///
 		/// \brief Construct a ScribeWrapper object
@@ -46,7 +47,9 @@ namespace poly_scribe
 		/// \param t_value rvalue reference to the value to wrap.
 		/// \param t_name name the value should to be serialized with.
 		///
-		ScribeWrapper( T &&t_value, std::string t_name ) : m_value( std::forward<T>( t_value ) ), m_name( std::move( t_name ) ) {}
+		ScribeWrapper( T &&t_value, std::string t_name, bool t_optional ) : m_value( std::forward<T>( t_value ) ), m_name( std::move( t_name ) ), m_optional( t_optional )
+		{
+		}
 
 		~ScribeWrapper( ) = default;
 

--- a/test/scribe-wrapper.cpp
+++ b/test/scribe-wrapper.cpp
@@ -174,4 +174,52 @@ TEMPLATE_TEST_CASE( "scribe-wrapper::base.pointer", "[scribe-wrapper][template]"
 	REQUIRE( *wrap.m_value.m_ptr == *value );
 }
 
+TEST_CASE( "scribe-wrapper::optional", "[scribe-wrapper]" )
+{
+	SECTION( "Exception handling" )
+	{
+		std::stringstream string_stream;
+		string_stream << "{}\n";
+		auto name      = GENERATE_RANDOM_STRING( 10 );
+		int prev_value = GENERATE_RANDOM( int, 2 );
+
+		{
+			cereal::JSONInputArchive archive( string_stream ); // NOLINT(misc-const-correctness)
+
+			int value = prev_value;
+
+			REQUIRE_THROWS_WITH( archive( poly_scribe::make_scribe_wrap( name, value, false ) ), Catch::Matchers::ContainsSubstring( "provided NVP" ) );
+			REQUIRE_NOTHROW( archive( poly_scribe::make_scribe_wrap( name, value, true ) ) );
+
+			REQUIRE( value == prev_value );
+		}
+	}
+
+	SECTION( "Value in archive" )
+	{
+		std::stringstream string_stream;
+		auto name     = GENERATE_RANDOM_STRING( 10 );
+		int new_value = GENERATE_RANDOM( int, 2 );
+		string_stream << "{\"" << name << "\":" << new_value << "}\n";
+		INFO( string_stream.str( ) );
+
+		{
+			cereal::JSONInputArchive archive( string_stream ); // NOLINT(misc-const-correctness)
+
+			int value = new_value * 2;
+
+			SECTION( "non opt value" )
+			{
+				REQUIRE_NOTHROW( archive( poly_scribe::make_scribe_wrap( name, value, false ) ) );
+			}
+			SECTION( "opt value" )
+			{
+				REQUIRE_NOTHROW( archive( poly_scribe::make_scribe_wrap( name, value, true ) ) );
+			}
+
+			REQUIRE( value == new_value );
+		}
+	}
+}
+
 // NOLINTEND(readability-function-cognitive-complexity)

--- a/test/scribe-wrapper.cpp
+++ b/test/scribe-wrapper.cpp
@@ -180,8 +180,8 @@ TEST_CASE( "scribe-wrapper::optional", "[scribe-wrapper]" )
 	{
 		std::stringstream string_stream;
 		string_stream << "{}\n";
-		auto name      = GENERATE_RANDOM_STRING( 10 );
-		int prev_value = GENERATE_RANDOM( int, 2 );
+		const auto name      = GENERATE_RANDOM_STRING( 10 );
+		const auto prev_value = GENERATE_RANDOM( int, 2 );
 
 		{
 			cereal::JSONInputArchive archive( string_stream ); // NOLINT(misc-const-correctness)
@@ -198,8 +198,8 @@ TEST_CASE( "scribe-wrapper::optional", "[scribe-wrapper]" )
 	SECTION( "Value in archive" )
 	{
 		std::stringstream string_stream;
-		auto name     = GENERATE_RANDOM_STRING( 10 );
-		int new_value = GENERATE_RANDOM( int, 2 );
+		const auto name     = GENERATE_RANDOM_STRING( 10 );
+		const auto new_value = GENERATE_RANDOM( int, 2 );
 		string_stream << "{\"" << name << "\":" << new_value << "}\n";
 		INFO( string_stream.str( ) );
 


### PR DESCRIPTION
This PR implements deserializing values that are optional.
Currently, this is only supported for JSON archives. 
In the future, this should also be implemented for XML archives and it should be checked if binary archives work.