### PR TITLE
Add CMake export commands

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ CPMAddPackage (
 	NAME cereal
 	VERSION 1.3.2
 	GITHUB_REPOSITORY USCiLab/cereal
-	OPTIONS "SKIP_PERFORMANCE_COMPARISON ON" "BUILD_DOC OFF" "BUILD_SANDBOX OFF"
+	OPTIONS "SKIP_PERFORMANCE_COMPARISON ON" "BUILD_DOC OFF" "BUILD_SANDBOX OFF" "CEREAL_INSTALL ON"
 )
 
 add_library (${PROJECT_NAME} INTERFACE)
@@ -33,6 +33,33 @@ target_compile_features (${PROJECT_NAME} INTERFACE cxx_std_17)
 if (NOT CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
 	set_property (TARGET ${PROJECT_NAME} PROPERTY FOLDER poly-scribe)
 endif ()
+
+# based on cereal's CMakeLists.txt
+include (GNUInstallDirs)
+include (CMakePackageConfigHelpers)
+
+install (TARGETS ${PROJECT_NAME} EXPORT ${PROJECT_NAME}Targets)
+install (DIRECTORY include/poly-scribe DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+
+set (configFile ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake)
+set (versionFile ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake)
+set (configInstallDestination ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
+
+configure_package_config_file (
+	${CMAKE_CURRENT_SOURCE_DIR}/cmake/Config.cmake.in ${configFile} INSTALL_DESTINATION ${configInstallDestination}
+)
+if (${CMAKE_VERSION} VERSION_GREATER 3.13)
+	write_basic_package_version_file ("${versionFile}" COMPATIBILITY SameMajorVersion ARCH_INDEPENDENT)
+else ()
+	write_basic_package_version_file ("${versionFile}" COMPATIBILITY SameMajorVersion)
+endif ()
+
+install (FILES ${configFile} ${versionFile} DESTINATION ${configInstallDestination})
+install (
+	EXPORT ${PROJECT_NAME}Targets
+	NAMESPACE "poly-scribe::"
+	DESTINATION ${configInstallDestination}
+)
 
 # Don't even look at tests if we're not top-level
 if (NOT PROJECT_IS_TOP_LEVEL)

--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -1,0 +1,3 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")


### PR DESCRIPTION
As the title states, this PR adds CMake export commands to the library such that other libraries can be exported that link to poly-scribe.