### PR TITLE
Fix: creation of the additional data for the code generation

### DIFF
--- a/code-gen/src/poly_scribe_code_gen/cli/__init__.py
+++ b/code-gen/src/poly_scribe_code_gen/cli/__init__.py
@@ -40,7 +40,7 @@ def poly_scribe_code_gen():
     with open(args.additional_data) as f:
         additional_data: AdditionalData = json.load(f)
 
-    additional_data["year"] = datetime.datetime.now(tz=datetime.timezone.utc).date().year
+    additional_data["year"] = str(datetime.datetime.now(tz=datetime.timezone.utc).date().year)
     additional_data["out_file"] = args.cpp.name if args.cpp else None
 
     if args.cpp:

--- a/code-gen/src/poly_scribe_code_gen/cli/__init__.py
+++ b/code-gen/src/poly_scribe_code_gen/cli/__init__.py
@@ -41,7 +41,7 @@ def poly_scribe_code_gen():
         additional_data: AdditionalData = json.load(f)
 
     additional_data["year"] = datetime.datetime.now(tz=datetime.timezone.utc).date().year
-    additional_data["out_file"] = args.cpp.name if args.cpp else args.py.name
+    additional_data["out_file"] = args.cpp.name if args.cpp else None
 
     if args.cpp:
         cpp_idl_copy = copy.deepcopy(parsed_idl)

--- a/code-gen/src/poly_scribe_code_gen/cpp_gen.py
+++ b/code-gen/src/poly_scribe_code_gen/cpp_gen.py
@@ -4,7 +4,7 @@
 
 import os
 from pathlib import Path
-from typing import Any, TypedDict
+from typing import Any, Optional, TypedDict
 
 import jinja2
 
@@ -12,7 +12,7 @@ import jinja2
 class AdditionalData(TypedDict):
     author_name: str
     author_email: str
-    out_file: str
+    out_file: Optional[str]
     year: str
     licence: str
     namespace: str


### PR DESCRIPTION
The code generation could fail if some settings were not correct. This PR should address this by making the `out_file` parameter optional. This is easily possible as only the cpp code generation uses it.

This should also fix #25