### PR TITLE
Feature: optional dictionaries, also with polymorphic types

### DIFF
--- a/code-gen/README.md
+++ b/code-gen/README.md
@@ -1,3 +1,25 @@
 # poly-scribe-code-gen
 
 Generate code for serializing data structures from WebIDL definitions.
+
+## Documentation
+
+### Fixed size arrays
+
+In order to get a fixed-size array or vector, the extra argument `Size` can be used.
+For example, an array with 4 `double` can be defined as:
+
+```
+[Size=4] sequence<double> four_elements;
+```
+
+### Polymorphic default values
+
+Default values for polymorphic types are tricky.
+The syntax is as follows:
+
+```
+[Default=DerivedType] BaseType default_poly = {};
+```
+
+However for this to work correctly, all members of the DerivedType must either have a default value or be optional/nullable.

--- a/code-gen/src/poly_scribe_code_gen/cpp_gen.py
+++ b/code-gen/src/poly_scribe_code_gen/cpp_gen.py
@@ -100,6 +100,9 @@ def _transform_types(parsed_idl):
         for member in struct["members"]:
             member["type"] = _transformer(member["type"])
 
+            if "shared_ptr" in member["type"] and isinstance(member["default"], dict):
+                member["default"] = f"std::make_shared<{member["default"]["value"]}>()"
+
     for type_def in parsed_idl["type_defs"]:
         type_def["type"] = _transformer(type_def["type"])
 

--- a/code-gen/src/poly_scribe_code_gen/matlab_gen.py
+++ b/code-gen/src/poly_scribe_code_gen/matlab_gen.py
@@ -176,6 +176,9 @@ def _transform_types(parsed_idl):
                 else:
                     member["default"] = f"cell{variable_shape}"
 
+            if isinstance(member["default"], dict):
+                member["default"] = member["default"]["value"]
+
             member["validation"] = {
                 "must_be": ", ".join(f'"{t}"' for t in foo[0]),
                 "size": variable_shape,

--- a/code-gen/src/poly_scribe_code_gen/py_gen.py
+++ b/code-gen/src/poly_scribe_code_gen/py_gen.py
@@ -133,8 +133,8 @@ def _transform_types(parsed_idl):
                 if isinstance(member["default"], dict):
                     member["default"] = f"{member["default"]["value"]}()"
 
-        for _, derived_types in parsed_idl["inheritance_data"].items():
-            if struct["name"] in derived_types:
+        for base_type, derived_types in parsed_idl["inheritance_data"].items():
+            if (struct["name"] in derived_types or struct["name"] == base_type) and len(derived_types) > 1:
                 # check if there is no member in struct is already named "type"
                 if not any(member["name"] == "type" for member in struct["members"]):
                     struct_name = struct["name"]
@@ -143,7 +143,7 @@ def _transform_types(parsed_idl):
                             "name": "type",
                             "type": f'Literal["{struct_name}"]',
                             "extra_data": ExtraData(),
-                            "default": f"{struct_name}",
+                            "default": f"\"{struct_name}\"",
                         }
                     )
 

--- a/code-gen/src/poly_scribe_code_gen/py_gen.py
+++ b/code-gen/src/poly_scribe_code_gen/py_gen.py
@@ -130,6 +130,9 @@ def _transform_types(parsed_idl):
             if extra_data.polymorphic:
                 member["type"] = f"Annotated[{member['type']}, Field(discriminator=\"type\")]"
 
+                if isinstance(member["default"], dict):
+                    member["default"] = f"{member["default"]["value"]}()"
+
         for _, derived_types in parsed_idl["inheritance_data"].items():
             if struct["name"] in derived_types:
                 # check if there is no member in struct is already named "type"

--- a/code-gen/src/poly_scribe_code_gen/templates/python.jinja
+++ b/code-gen/src/poly_scribe_code_gen/templates/python.jinja
@@ -21,7 +21,7 @@ class {{ enum.name }}(IntEnum):
 {% for struct in structs%}
 class {{ struct.name }}{% if struct.inheritance %}({{ struct.inheritance }}){% else %}(BaseModel){% endif %}:
     {% for member in struct.members %}
-    {{ member.name }}: {{ member.type }}{% if member.default %} = "{{ member.default }}"{% endif +%}
+    {{ member.name }}: {{ member.type }}{% if member.default %} = {{ member.default }}{% endif +%}
     {% endfor %}
     {% if not struct.members %}
     pass

--- a/test/integration.webidl
+++ b/test/integration.webidl
@@ -31,6 +31,21 @@ dictionary NonPolyDerived : NonPolyBase
     int value;
 };
 
+dictionary OptionalPolyBase
+{
+};
+
+dictionary OptionalPolyDerived : OptionalPolyBase
+{
+    int value = 42;
+};
+
+dictionary OptionalPolyDerived2 : OptionalPolyBase
+{
+    int value = 100;
+    string name = "default";
+};
+
 dictionary IntegrationTest
 {
     record<ByteString, Base> object_map;
@@ -42,4 +57,6 @@ dictionary IntegrationTest
     Enumeration enum_value;
 
     NonPolyDerived non_poly_derived;
+
+    [Default=OptionalPolyDerived2] OptionalPolyBase optional_poly = {};
 };


### PR DESCRIPTION
In WebIDL, non pod types that have a default value must be indicated by setting them to `{}`.

1. This caused errors in the code generation
2. This did not allow polymorphic datastructures to defined the default object.

With this PR, both these issues are dealt with.