### PR TITLE
Feature: refine cpp optional values

### DIFF
--- a/code-gen/src/poly_scribe_code_gen/cpp_gen.py
+++ b/code-gen/src/poly_scribe_code_gen/cpp_gen.py
@@ -90,7 +90,7 @@ def _transform_types(parsed_idl: ParsedIDL) -> ParsedIDL:
     for struct_data in parsed_idl["structs"].values():
         for member_data in struct_data["members"].values():
             member_data["type"] = _transformer(member_data["type"], parsed_idl["inheritance_data"])
-            if not member_data["required"]:
+            if not member_data["required"] and member_data["default"] is None:
                 member_data["type"] = f"std::optional<{member_data['type']}>"
 
             if "std::string" in member_data["type"] and member_data["default"]:

--- a/code-gen/tests/cpp_gen_test.py
+++ b/code-gen/tests/cpp_gen_test.py
@@ -404,7 +404,7 @@ dictionary Foo {
 
     result = cpp_gen._render_template(parsed_idl, {"package": "test"})
 
-    assert "std::optional<int> foo = 42;".replace(" ", "") in result.replace(" ", "")
+    assert "int foo = 42;".replace(" ", "") in result.replace(" ", "")
     assert "std::optional<int> bar;".replace(" ", "") in result.replace(" ", "")
     assert "namespace test" in result
 
@@ -549,7 +549,7 @@ dictionary Foo {
     for match in matches:
         struct_body = match[1]
         if match[0] == "Foo":
-            assert 'std::optional<std::string> foo = "bar";'.replace(" ", "") in struct_body.replace(" ", "")
+            assert 'std::string foo = "bar";'.replace(" ", "") in struct_body.replace(" ", "")
 
 
 def test__render_template_boolean_default_value() -> None:
@@ -571,4 +571,4 @@ dictionary Foo {
     for match in matches:
         struct_body = match[1]
         if match[0] == "Foo":
-            assert "std::optional<bool> foo = true;".replace(" ", "") in struct_body.replace(" ", "")
+            assert "bool foo = true;".replace(" ", "") in struct_body.replace(" ", "")


### PR DESCRIPTION
If a variable has a default value, it does not have to be an std::optional. This PR fixes this and adapts the tests accordingly. 