### PR TITLE
Refactor: Defaulted members must be optional

### DIFF
--- a/code-gen/src/poly_scribe_code_gen/cpp_gen.py
+++ b/code-gen/src/poly_scribe_code_gen/cpp_gen.py
@@ -90,7 +90,7 @@ def _transform_types(parsed_idl: ParsedIDL) -> ParsedIDL:
     for struct_data in parsed_idl["structs"].values():
         for member_data in struct_data["members"].values():
             member_data["type"] = _transformer(member_data["type"], parsed_idl["inheritance_data"])
-            if not member_data["required"] and member_data["default"] is None:
+            if not member_data["required"]:
                 member_data["type"] = f"std::optional<{member_data['type']}>"
 
             if "std::string" in member_data["type"] and member_data["default"]:

--- a/code-gen/src/poly_scribe_code_gen/py_gen.py
+++ b/code-gen/src/poly_scribe_code_gen/py_gen.py
@@ -170,7 +170,7 @@ def _transform_types(parsed_idl: ParsedIDL) -> ParsedIDL:
                     type_str = type_str[1:-1]
                 member_data["default"] = f"{type_str}()"
 
-            if not member_data["required"] and member_data["default"] is None:
+            if not member_data["required"]:
                 member_data["type"] = f"Optional[{member_data['type']}]"
 
             if "str" in member_data["type"] and member_data["default"] is not None:

--- a/code-gen/tests/cpp_gen_test.py
+++ b/code-gen/tests/cpp_gen_test.py
@@ -404,7 +404,7 @@ dictionary Foo {
 
     result = cpp_gen._render_template(parsed_idl, {"package": "test"})
 
-    assert "int foo = 42;".replace(" ", "") in result.replace(" ", "")
+    assert "std::optional<int> foo = 42;".replace(" ", "") in result.replace(" ", "")
     assert "std::optional<int> bar;".replace(" ", "") in result.replace(" ", "")
     assert "namespace test" in result
 
@@ -549,7 +549,7 @@ dictionary Foo {
     for match in matches:
         struct_body = match[1]
         if match[0] == "Foo":
-            assert 'std::string foo = "bar";'.replace(" ", "") in struct_body.replace(" ", "")
+            assert 'std::optional<std::string> foo = "bar";'.replace(" ", "") in struct_body.replace(" ", "")
 
 
 def test__render_template_boolean_default_value() -> None:
@@ -572,8 +572,8 @@ dictionary Foo {
     for match in matches:
         struct_body = match[1]
         if match[0] == "Foo":
-            assert "bool foo = true;".replace(" ", "") in struct_body.replace(" ", "")
-            assert "bool bar = false;".replace(" ", "") in struct_body.replace(" ", "")
+            assert "std::optional<bool> foo = true;".replace(" ", "") in struct_body.replace(" ", "")
+            assert "std::optional<bool> bar = false;".replace(" ", "") in struct_body.replace(" ", "")
 
 
 def test_render_template_struct_with_multi_inheritance() -> None:
@@ -673,4 +673,4 @@ def test_render_template_struct_with_empty_type_default() -> None:
     for match in matches:
         struct_body = match[1]
         if match[0] == "Data":
-            assert "Base_t base = Foo{};".replace(" ", "") in struct_body.replace(" ", "")
+            assert "std::optional<Base_t> base = Foo{};".replace(" ", "") in struct_body.replace(" ", "")

--- a/code-gen/tests/py_gen_test.py
+++ b/code-gen/tests/py_gen_test.py
@@ -285,7 +285,7 @@ dictionary Foo {
 
     result = py_gen._render_template(parsed_idl, {"package": "test"})
 
-    assert "foo: int = 42".replace(" ", "") in result.replace(" ", "")
+    assert "foo: Optional[int] = 42".replace(" ", "") in result.replace(" ", "")
     assert "bar: Optional[int] = None".replace(" ", "") in result.replace(" ", "")
 
 
@@ -564,7 +564,7 @@ dictionary Foo {
     for match in matches:
         struct_body = match[2]
         if match[0] == "Foo":
-            assert 'foo: str = "bar"'.replace(" ", "") in struct_body.replace(" ", "")
+            assert 'foo: Optional[str] = "bar"'.replace(" ", "") in struct_body.replace(" ", "")
 
 
 def test_render_template_struct_with_empty_type_default() -> None:
@@ -600,7 +600,7 @@ def test_render_template_struct_with_empty_type_default() -> None:
     for match in matches:
         struct_body = match[2]
         if match[0] == "Data":
-            assert 'base: Annotated[Union["Foo", "Bar", "Base"],Field(discriminator="type")] = Foo()'.replace(
+            assert 'base: Optional[Annotated[Union["Foo", "Bar", "Base"],Field(discriminator="type")]] = Foo()'.replace(
                 " ", ""
             ) in struct_body.replace(" ", "")
         elif match[0] == "Base":
@@ -609,7 +609,7 @@ def test_render_template_struct_with_empty_type_default() -> None:
             assert 'type: Literal["Foo"] = "Foo"'.replace(" ", "") in struct_body.replace(" ", "")
         elif match[0] == "Bar":
             assert 'type: Literal["Bar"] = "Bar"'.replace(" ", "") in struct_body.replace(" ", "")
-            assert "value: int = int()".replace(" ", "") in struct_body.replace(" ", "")
+            assert "value: Optional[int] = int()".replace(" ", "") in struct_body.replace(" ", "")
 
 
 def test__render_template_boolean_default_value() -> None:
@@ -630,5 +630,5 @@ dictionary Foo {
     for match in matches:
         struct_body = match[2]
         if match[0] == "Foo":
-            assert "foo: bool = True".replace(" ", "") in struct_body.replace(" ", "")
-            assert "bar: bool = False".replace(" ", "") in struct_body.replace(" ", "")
+            assert "foo: Optional[bool] = True".replace(" ", "") in struct_body.replace(" ", "")
+            assert "bar: Optional[bool] = False".replace(" ", "") in struct_body.replace(" ", "")


### PR DESCRIPTION
During usage of the package, it was found, that defaulted members must be optional for the reflect-cpp deserialization to work correctly. If they are not optional, the deserialization can fail if the defaulted member is not in the input data.