### PR TITLE
Fix: string fields with default value missing doc strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix documentation generation for string fields with default values (#66)
+
 ## [1.0.2] - 2026-08-17
 
 ### Fixed

--- a/code-gen/src/poly_scribe_code_gen/parse_idl.py
+++ b/code-gen/src/poly_scribe_code_gen/parse_idl.py
@@ -436,7 +436,7 @@ def _find_comments(idl: str) -> dict[str, dict[tuple[str, ...], str]]:
             comment_part = split_line[1].strip()
 
             key = identifier_regex.findall(code_part)
-            key_flat = [item for sublist in key for item in sublist if item]
+            key_flat = [next(item for sublist in key for item in sublist if item)]
 
             # Prepend current dictionary name if inside a dictionary scope
             current_dict = next(
@@ -466,7 +466,7 @@ def _find_comments(idl: str) -> dict[str, dict[tuple[str, ...], str]]:
             tmp_block_comment += idl_line_strip + "\n"
         elif in_block_comment or multi_line_block_comment_end:
             key = identifier_regex.findall(idl_line_strip)
-            key_flat = [item for sublist in key for item in sublist if item]
+            key_flat = [next(item for sublist in key for item in sublist if item)]
 
             # Prepend current dictionary name if inside a dictionary scope
             current_dict = next(

--- a/code-gen/tests/py_gen_test.py
+++ b/code-gen/tests/py_gen_test.py
@@ -507,6 +507,7 @@ dictionary Bar {
     /// Different comment for bar
     float bar;
     float foo; ///< inline comment for foo
+    string s = "default"; ///< inline comment for s
 };
 
 /// Typedef comment
@@ -529,7 +530,7 @@ enum MyEnum {
     pattern = re.compile(r'"""\s*(.*?)\s*"""', re.DOTALL)
     matches = pattern.findall(result)
 
-    assert len(matches) == 12
+    assert len(matches) == 13
     assert "Typedef comment\n\ninline typedef comment" in matches[0]
     assert "My Enum comment" in matches[1]
     assert "Enum value 1 comment" in matches[2]
@@ -545,8 +546,9 @@ enum MyEnum {
     assert "Short comment for bar" in matches[7]
     assert "Different comment for bar" in matches[8]
     assert "inline comment for foo" in matches[9]
-    assert "Load" in matches[10]
-    assert "Save" in matches[11]
+    assert "inline comment for s" in matches[10]
+    assert "Load" in matches[11]
+    assert "Save" in matches[12]
 
 
 def test__render_template_string_default_value() -> None:


### PR DESCRIPTION
As the title and commit message of 5753572becb61b2bd5413fc44af51221de5dbacc states.